### PR TITLE
Fixes #1 - Add prettier to output

### DIFF
--- a/root/package.json.ejs
+++ b/root/package.json.ejs
@@ -7,12 +7,22 @@
     "bugs": "<%- repositoryBugsUrl %>",
     "author": "<%- author %>",
     "keywords": [],
-    "devDependencies": {},
+    "devDependencies": {
+        "prettier": "^1.13.5"
+    },
     "dependencies": {},
 <% if (license === 'UNLICENSED' || !isNpmPkg ) { %>
     "private": true,
 <% } %>
     "license": "<%- license %>",
+    "prettier": {
+        "printWidth": 100,
+        "trailingComma": "es5",
+        "proseWrap": "always",
+        "semi": false,
+        "requirePragma": false,
+        "insertPragma": false
+    },
     "scripts": {
         "test": "echo 'Error: no tests specified' && exit 1"
     }


### PR DESCRIPTION
Given that I nearly always have at minimum Markdown files in projects it
makes sense to install Prettier using npm into the project.